### PR TITLE
Specify store instance #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ deploy:
   provider: npm
   email: $NPM_USER
   api_key: $NPM_TOKEN
+  edge: true
   on:
     tags: true
     repo: EliuX/serverless-migrate-plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Before release 1.0.3 - 2020-02-07
+### Before release 2.0.0 - 2020-02-07
+### Added
+- Changes the param `store` and adds `state-file`:
+    * `store`: Path where to get the class in charge of managing the migration data. If it is not
+    specified it will use the default implementation which stores it in a file, i.e. `.migrate`.
+    * `state-file`: Set the path of the state file. This path is also passed to the constructor of 
+    the class specified by `store`.
+
+### Before release 1.0.2 - 2020-02-07
+### Added
 - Allows to override environment variables
 
 ## Before release 1.0.1 - 2019-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Before release 2.0.0 - 2020-02-07
 ### Added
+- Allows to override environment variables
+### Changed
 - Changes the param `store` and adds `state-file`:
     * `store`: Path where to get the class in charge of managing the migration data. If it is not
     specified it will use the default implementation which stores it in a file, i.e. `.migrate`.
     * `state-file`: Set the path of the state file. This path is also passed to the constructor of 
     the class specified by `store`.
-
-### Before release 1.0.2 - 2020-02-07
-### Added
-- Allows to override environment variables
 
 ## Before release 1.0.1 - 2019-09-06
 ### Added

--- a/example/README.md
+++ b/example/README.md
@@ -127,10 +127,10 @@ It is also noticed that the one afterwards is not applied, because it says `[not
 
 Sometimes we need to keep track of different migrations for a same application. For instance, imagine that we want to 
 track migrations for different stages of our application, e.g. test, staging and production. It can be done by 
-specifying the option `storage` and the folder where we want to put it:
+specifying the option `state-file` and the folder where we want to put it:
 
 ```bash
-sls migrate list --storage=.migrate-$SLS_STAGE
+sls migrate list --state-file=.migrate-$SLS_STAGE
 ```
 
 This way we have a migration file per stage:
@@ -138,6 +138,17 @@ This way we have a migration file per stage:
 - .migrate-test
 - .migrate-staging
 - .migrate-production
+
+In case you want to use your own handler for storing and retrieving the data related to the state of the migrations, you
+can specify the a class for handling it, with the option `store`. E.g.
+
+```bash
+sls migrate list --store=./src/mongodb-store
+```
+
+Check out the [official documentation of migrate][migrate-npm] for more information, but it is recommended to use
+`node_modules/migrate/lib/file-store.js` as a reference.
+ 
 
 ### Going a little further
 
@@ -220,9 +231,11 @@ do action using ANOTHER_ENV=overrriden value
 In the serverless.yml in the section custom.migrate, we can define variables that will change
 aspects of our migrations:
 
-* `store`: The migration states store file you want to use
-* `lastRunIndicator`: The text to append to the last migration that is applied
-* `noDescriptionText`: Text to show when a migration has no description
+* `state-file`: The file where you want the migrations to be stored.
+* `store`: The class that will handle the migrations. By default it uses the one 
+in `node_modules/migrate/lib/file-store.js`.
+* `lastRunIndicator`: The text to append to the last migration that is applied.
+* `noDescriptionText`: Text to show when a migration has no description.
 * `ignoreMissing`: Ignores missing migration files if they are not found. 
 * `dateFormat`: The date format to use on the reports. By default it uses `yyyy-mm-dd`.
 * `templateFile`: The template to use to create your migrations.
@@ -235,7 +248,8 @@ E.g.
 ```yaml
 custom:
   migrate:
-    store: .migrate2
+    stateFile: .migrate2
+    store: ./sample-store
     lastRunIndicator: <
     noDescriptionText: '?'
     ignoreMissing: true

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "list": "sls migrate list",
     "up": "sls migrate up",
-    "down": "sls migrate down"
+    "down": "sls migrate down --store=\" \""
   },
   "author": "Eliecer Hernandez <eliecerhdz@gmail.com> (https://eliux.github.io)",
   "license": "ISC",

--- a/example/sample-store.js
+++ b/example/sample-store.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const fs = require('fs');
+
+function FileStore2(path) {
+  this.path = path;
+}
+
+/**
+ * Save the migration data.
+ *
+ * @api public
+ */
+
+FileStore2.prototype.save = function (set, fn) {
+  console.log('custom saver...');
+  fs.writeFile(this.path, JSON.stringify({
+    lastRun: set.lastRun,
+    migrations: set.migrations,
+  }, null, '  '), fn);
+};
+
+/**
+ * Load the migration data and call `fn(err, obj)`.
+ *
+ * @param {Function} fn
+ * @return {Type}
+ * @api public
+ */
+
+FileStore2.prototype.load = function (fn) {
+  console.log('custom loader...');
+  fs.readFile(this.path, 'utf8', (err, json) => {
+    if (err && err.code !== 'ENOENT') return fn(err);
+    if (!json || json === '') {
+      return fn(null, {});
+    }
+
+    let store;
+    try {
+      store = JSON.parse(json);
+      // eslint-disable-next-line no-shadow
+    } catch (err) {
+      return fn(err);
+    }
+
+    // Check if old format and convert if needed
+    // eslint-disable-next-line no-prototype-builtins
+    if (!store.hasOwnProperty('lastRun') && store.hasOwnProperty('pos')) {
+      if (store.pos === 0) {
+        store.lastRun = null;
+      } else {
+        if (store.pos > store.migrations.length) {
+          return fn(new Error('Store file contains invalid pos property'));
+        }
+
+        store.lastRun = store.migrations[store.pos - 1].title;
+      }
+
+      // In-place mutate the migrations in the array
+      store.migrations.forEach((migration, index) => {
+        if (index < store.pos) {
+          // eslint-disable-next-line no-param-reassign
+          migration.timestamp = Date.now();
+        }
+      });
+    }
+
+    // Check if does not have required properties
+    // eslint-disable-next-line no-prototype-builtins
+    if (!store.hasOwnProperty('lastRun') || !store.hasOwnProperty('migrations')) {
+      return fn(new Error('Invalid store file'));
+    }
+
+    return fn(null, store);
+  });
+};
+
+module.exports = FileStore2;

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -8,7 +8,8 @@ provider:
     ANOTHER_ENV: original content
 custom:
   migrate:
-    store: .migrate2
+    stateFile: .migrate2
+    store: ./sample-store
     lastRunIndicator: <
     noDescriptionText: '?'
     ignoreMissing: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-migrate-plugin",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-migrate-plugin",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Serverless plugin for migrate",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR changes the way store was used before.
Before:
* `store`: The migration states store file you want to use.
Now:
    * `store`: Path where to get the class in charge of managing the migration data. If it is not
    specified it will use the default implementation which stores it in a file, i.e. `.migrate`.
    * `state-file`: Set the path of the state file. This path is also passed to the constructor of 
    the class specified by `store`.