### PR TITLE
Fix missing environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ class MigratePlugin {
 
     this.config = this.serverless.service.custom ? this.serverless.service.custom.migrate : {};
     process.env = this.serverless.service.provider.environment = {
+      ...process.env,
       ...this.serverless.service.provider.environment,
       ...this.config.environment,
     };


### PR DESCRIPTION
Without merging the original `process.env` we will lost all environment variables, and `serverless` will not be able to find some binary files